### PR TITLE
Make the pcie defer to use a device tree property

### DIFF
--- a/Documentation/kernel-parameters.txt
+++ b/Documentation/kernel-parameters.txt
@@ -3506,6 +3506,13 @@ bytes respectively. Such letter suffixes can also be entirely omitted.
 	rhash_entries=	[KNL,NET]
 			Set number of hash buckets for route cache
 
+	rkdwmmc_defer_time=
+			Minimum time in ms to wait for Rockchip pcie port to get initialized
+			and to defer Rockchip dw_mmc probe. This is a workaround for
+			Rockpro64 sdio0 and pcie conflict. Only enabled with
+			CONFIG_PCIE_ROCKCHIP.
+			Default value is 2000.
+
 	ro		[KNL] Mount root device read-only on boot
 
 	rockchip.usb_uart

--- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
@@ -332,7 +332,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
 	sd-uhs-sdr104;
-	status = "disabled";
+	status = "okay";
 };
 
 &emmc_phy {

--- a/drivers/mmc/host/dw_mmc-rockchip.c
+++ b/drivers/mmc/host/dw_mmc-rockchip.c
@@ -6,7 +6,6 @@
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  */
-
 #include <linux/ktime.h>
 #include <linux/module.h>
 #include <linux/moduleparam.h>
@@ -204,10 +203,16 @@ free:
 	return ret;
 }
 
+#ifdef CONFIG_PCIE_ROCKCHIP
+extern bool rk_pcie_port_initialized;
+static s64 defer_start = 0, elapsed = 0;
+#endif
+
 static int dw_mci_rk3288_parse_dt(struct dw_mci *host)
 {
 	struct device_node *np = host->dev->of_node;
 	struct dw_mci_rockchip_priv_data *priv;
+	int defer_pcie;
 
 	priv = devm_kzalloc(host->dev, sizeof(*priv), GFP_KERNEL);
 	if (!priv)
@@ -224,6 +229,26 @@ static int dw_mci_rk3288_parse_dt(struct dw_mci *host)
 	priv->sample_clk = devm_clk_get(host->dev, "ciu-sample");
 	if (IS_ERR(priv->sample_clk))
 		dev_dbg(host->dev, "ciu_sample not available\n");
+
+#ifdef CONFIG_PCIE_ROCKCHIP
+	if (of_property_read_u32(np, "defer_pcie", &defer_pcie))
+		defer_pcie = 0;
+
+	if (defer_pcie > 0) {
+		if (!rk_pcie_port_initialized) {
+			if (defer_start == 0)
+				defer_start = ktime_to_ms(ktime_get());
+			elapsed = ktime_to_ms(ktime_get()) - defer_start;
+			if (elapsed <= defer_pcie) {
+				dev_info(host->dev, "deferring for a max of %dms while pcie port initializes. Waited %lldms so far.\n", defer_pcie, elapsed);
+				return -EPROBE_DEFER;
+			} else
+				dev_info(host->dev, "probe defer timed out waiting for pcie init, continuing...\n");
+		} else {
+			dev_info(host->dev, "detected pcie initialized, continuing...\n");
+		}
+	}
+#endif
 
 	host->priv = priv;
 
@@ -277,31 +302,10 @@ static const struct of_device_id dw_mci_rockchip_match[] = {
 };
 MODULE_DEVICE_TABLE(of, dw_mci_rockchip_match);
 
-#ifdef CONFIG_PCIE_ROCKCHIP
-extern bool rk_pcie_port_initialized;
-static int rkdwmmc_defer_time = 2000;
-core_param(rkdwmmc_defer_time, rkdwmmc_defer_time, int, S_IRUGO);
-static s64 defer_start = 0;
-#endif
 static int dw_mci_rockchip_probe(struct platform_device *pdev)
 {
 	const struct dw_mci_drv_data *drv_data;
 	const struct of_device_id *match;
-
-#ifdef CONFIG_PCIE_ROCKCHIP
-	s64 now = ktime_to_ms(ktime_get());
-	if (!rk_pcie_port_initialized) {
-		if (defer_start == 0) {
-			defer_start = now;
-		}
-
-		if (now - defer_start < rkdwmmc_defer_time) {
-			dev_dbg(&pdev->dev, "deferring probe until pcie port initialized\n");
-			return -EPROBE_DEFER;
-		}
-		dev_warn(&pdev->dev, "no longer waiting for pcie port init\n");
-	}
-#endif
 
 	if (!pdev->dev.of_node)
 		return -ENODEV;

--- a/drivers/pci/host/pcie-rockchip.c
+++ b/drivers/pci/host/pcie-rockchip.c
@@ -1277,6 +1277,9 @@ static int __maybe_unused rockchip_pcie_resume_noirq(struct device *dev)
 	return 0;
 }
 
+bool rk_pcie_port_initialized = false;
+EXPORT_SYMBOL(rk_pcie_port_initialized);
+
 static int rockchip_pcie_probe(struct platform_device *pdev)
 {
 	struct rockchip_pcie *rockchip;
@@ -1335,6 +1338,7 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
 	}
 
 	err = rockchip_pcie_init_port(rockchip);
+	rk_pcie_port_initialized = true;
 	if (err)
 		goto err_vpcie;
 


### PR DESCRIPTION
This commit supports controlling what mmc nodes get deferred, rather than all of them. Simply append this to the node's device-tree to delay 2000 ms:
  defer_pcie = <2000>;